### PR TITLE
Allow compiler optimisations with -fno-delete-null-pointer-checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -fno-delete-null-pointer-checks")
 
 string(TIMESTAMP BUILD_TIMESTAMP "%Y%m%d-%H%M%S" UTC)
 


### PR DESCRIPTION
If at least `-O1` is given then the client crashes on startup without
disabling this optimisation. It is supported at least since GCC 3.4.

This was a tricky one to find because `-O0` works and `-O1` doesn't but
the GCC manual says this optimisation is only enabled at `-O2`. Turns
out it is also enabled by default on most targets.

It may be possible to narrow it down to a specific subproject or
source file but applying it globally seems safest.