### PR TITLE
Add USE_OWN_JSON CMake option to avoid downloading nlohmann_json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ if(NOT CMAKE_SIZEOF_VOID_P EQUAL 4)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m32")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32")
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 string(TIMESTAMP BUILD_TIMESTAMP "%Y%m%d-%H%M%S" UTC)
 
@@ -64,7 +63,12 @@ if (USE_OWN_CURL)
     include(ext/curl.cmake)
 endif()
 
-include(ext/json.cmake)
+option(USE_OWN_JSON "Downloads nlohmann_json as an ExternalProject dependency" ON)
+if (USE_OWN_JSON)
+    include(ext/json.cmake)
+else()
+    find_package(nlohmann_json REQUIRED)
+endif()
 
 option(USE_GAMECONTROLLERDB "Downloads gamecontrollerdb.txt from gabomdq/SDL_GameControllerDB" ON)
 if (USE_GAMECONTROLLERDB)


### PR DESCRIPTION
Gentoo Linux has this available as a package.

This cannot be applied as-is because it unfortunately requires a change to almost every submodule. The problem is that nlohmann_json's CMake module sets the C++ standard using the proper method, which conflicts with your method of directly setting `CMAKE_CXX_FLAGS`. nlohmann_json's `-std` flag then appears later in the list and so it applies C++11 rather than C++14, breaking the build. The correct solution is to use `target_compile_features` but I've had to do this for every C++ instance of `add_executable` and `add_library`. Rather than run around creating loads of forks, I could just send you one patch across all the submodules to make life easier. It's possible that some of the submodules don't need C++14 but I didn't check. Please let me know what you want to do.

This also conflicts with #131 but I'll fix that once one of these is merged.