### PR TITLE
Point glfw to patched glfw for macos

### DIFF
--- a/ext/glfw.cmake
+++ b/ext/glfw.cmake
@@ -2,7 +2,7 @@ include(ExternalProject)
 
 ExternalProject_Add(
         glfw3_ext
-        URL "https://github.com/glfw/glfw/archive/master.zip"
+        URL "https://github.com/minecraft-linux/glfw/archive/master.zip"
         INSTALL_DIR ${CMAKE_BINARY_DIR}/ext/glfw
         CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/ext/glfw" "-DBUILD_SHARED_LIBS=OFF" "-DCMAKE_C_FLAGS=-m32" "-DCMAKE_LINK_FLAGS=-m32" "-DCMAKE_LIBRARY_ARCHITECTURE=${CMAKE_LIBRARY_ARCHITECTURE}"
 )


### PR DESCRIPTION
glfw isn't able to use libangle by default, this repo fix this problem on MacOs
You will **need** to **disable** the **gl_core_patch** in the **client** first
**Will be Forced pushed Tomorrow**