### PR TITLE
Fix for 1.19.60.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Minecraft Version|Bug Description
 1.16.210 - 1.17.4X|Crafting is broken on x86 and x86_64 based devices
 1.16.210 - 1.17.4X|Textures are off by one on x86 and x86_64 based devices, enable texture patch in profile settings to mitigate this Bug
 1.16.210 - 1.17.4X|World Corruption while next to water
-1.16.210 - 1.18.1X|Store and skins not loading
-1.18.30 - latest|**The game stops loading between 55-60% depening on the OS, distro and Hardware you have to force reloading without waiting more than a second**. Store and skins not loading, the game prevents you from selecting a custom skin
+1.16.210 - latest|Downloading Content from the Minecraft Marketplace times out
+1.18.30 - latest|**The game stops loading between 55-60% depening on the OS, distro and Hardware you have to force reloading without waiting more than a second**
 
 # Wiki
 


### PR DESCRIPTION
> Fix for changed ABI in 1.19.60.26 beta. Mojang just changed signature of `Mouse::feed` from `(char, char, short, short, short, short)` to `(char, signed char, short, short, short, short)`. Not tested on ARM platforms, macOS. Code checks if `_ZN5Mouse4feedEccssss` exists, if not, it tries to use the symbol `_ZN5Mouse4feedEcassss` instead

Via https://github.com/minecraft-linux/mcpelauncher-client/pull/36