### PR TITLE
reorder nativecallbacks / Set isChromebook to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Minecraft Version|Bug Description
 1.16.210 - 1.17.4X|Textures are off by one on x86 and x86_64 based devices, enable texture patch in profile settings to mitigate this Bug
 1.16.210 - 1.17.4X|World Corruption while next to water
 1.16.210 - latest|Downloading Content from the Minecraft Marketplace times out
-1.18.30 - latest|**The game stops loading between 55-60% depening on the OS, distro and Hardware you have to force reloading without waiting more than a second**
 
 # Wiki
 

--- a/ext/glfw.cmake
+++ b/ext/glfw.cmake
@@ -7,7 +7,7 @@ set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
         glfw3_ext
-        URL "https://github.com/minecraft-linux/glfw/archive/master.zip"
+        URL "https://github.com/minecraft-linux/glfw/archive/fce9121962bc0a21c39e2d6f8e08bad30c566c72.zip"
 )
 
 FetchContent_GetProperties(glfw3_ext)


### PR DESCRIPTION
* This fixes the random loading freeze on 56% during loading the game
* Makes the game more optimized for computer by default (Classic UI by default, smaller GUI scale, outline selection on by default)

Closes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/746
Closes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/750
Closes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/760
Closes https://github.com/minecraft-linux/mcpelauncher-manifest/issues/771
Closes https://github.com/ChristopherHX/osx-packaging-scripts/issues/13